### PR TITLE
NFL playoffs 2018

### DIFF
--- a/app/leagues/nfl_hensley.py
+++ b/app/leagues/nfl_hensley.py
@@ -16,7 +16,7 @@ def build_league(optimize: bool = False) -> League:
     get_score = hensley_cdf_builder(league)
     for g in league.games:
         g.set_score(get_score(g))
-    params = [10135.827483152862, 11418.89391604717]
+    params = [10135.827483152862, 11418.89418889558]
 
     def evaluate(x):
         # reset hack

--- a/examples/nfl/playoffs_2018.ipynb
+++ b/examples/nfl/playoffs_2018.ipynb
@@ -1,0 +1,166 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "sys.path.append('../../app/leagues/')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import random\n",
+    "from collections import Counter\n",
+    "\n",
+    "from glicko.update import calc_win_prob\n",
+    "\n",
+    "from nfl_hensley import build_league"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "league = build_league()\n",
+    "\n",
+    "team_lookup = {\n",
+    "    t.name: t for t in league.teams\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "afc = [\n",
+    "    team_lookup[t] for t in\n",
+    "    ['Chiefs', 'Patriots', 'Texans', 'Ravens', 'Chargers', 'Colts']\n",
+    "]\n",
+    "\n",
+    "nfc = [\n",
+    "    team_lookup[t] for t in\n",
+    "    ['Saints', 'Rams', 'Bears', 'Cowboys', 'Seahawks', 'Eagles']\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_winner(team_a, team_b):\n",
+    "    p = calc_win_prob(team_a.rating, team_b.rating)\n",
+    "    return team_a if p > random.random() else team_b\n",
+    "\n",
+    "def run_conference(teams):\n",
+    "    # teams is a list of the 6 seeds\n",
+    "    # Gonna do this the Monte Carlo way b/c less code/thinking :)\n",
+    "    div0 = get_winner(teams[2], teams[5])\n",
+    "    div1 = get_winner(teams[3], teams[4])\n",
+    "    \n",
+    "    if div0 == teams[5]:\n",
+    "        lower_div, higher_div = div0, div1\n",
+    "    else:\n",
+    "        lower_div, higher_div = div1, div0\n",
+    "    \n",
+    "    ch0 = get_winner(teams[0], lower_div)\n",
+    "    ch1 = get_winner(teams[1], higher_div)\n",
+    "    return get_winner(ch0, ch1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def run_playoffs(afc, nfc):\n",
+    "    afc_champ = run_conference(afc)\n",
+    "    nfc_champ = run_conference(nfc)\n",
+    "    return get_winner(afc_champ, nfc_champ)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "winners = [\n",
+    "    run_playoffs(afc, nfc)\n",
+    "    for _ in range(int(1e6))\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.173784\tTeam(name=Saints, rating=(1622.2506077092312, 5611.737038922921))\n",
+      "0.172482\tTeam(name=Chiefs, rating=(1617.8262887350143, 5777.087836068869))\n",
+      "0.164673\tTeam(name=Patriots, rating=(1614.8777467699877, 6422.9258324619095))\n",
+      "0.136643\tTeam(name=Rams, rating=(1595.1493081532103, 5638.337109199486))\n",
+      "0.055233\tTeam(name=Ravens, rating=(1579.1415676404824, 5628.188412486042))\n",
+      "0.054203\tTeam(name=Seahawks, rating=(1569.325322311265, 5692.750401483499))\n",
+      "0.052313\tTeam(name=Chargers, rating=(1575.6683520717681, 5686.877352955613))\n",
+      "0.051420\tTeam(name=Eagles, rating=(1573.0877526752258, 5763.175694404063))\n",
+      "0.049454\tTeam(name=Bears, rating=(1568.2953769418104, 5658.668224549107))\n",
+      "0.035592\tTeam(name=Texans, rating=(1531.140310186461, 5632.326645701227))\n",
+      "0.030325\tTeam(name=Cowboys, rating=(1529.6153074263095, 5562.54489659418))\n",
+      "0.023878\tTeam(name=Colts, rating=(1504.7960540254635, 5722.50979574115))\n"
+     ]
+    }
+   ],
+   "source": [
+    "for t, count in sorted(Counter(winners).items(), reverse=True, key=lambda t: t[1]):\n",
+    "    print(f'{count / len(winners):.06f}\\t{t}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Super Bowl win probs:

```
0.173784	Team(name=Saints, rating=(1622.2506077092312, 5611.737038922921))
0.172482	Team(name=Chiefs, rating=(1617.8262887350143, 5777.087836068869))
0.164673	Team(name=Patriots, rating=(1614.8777467699877, 6422.9258324619095))
0.136643	Team(name=Rams, rating=(1595.1493081532103, 5638.337109199486))
0.055233	Team(name=Ravens, rating=(1579.1415676404824, 5628.188412486042))
0.054203	Team(name=Seahawks, rating=(1569.325322311265, 5692.750401483499))
0.052313	Team(name=Chargers, rating=(1575.6683520717681, 5686.877352955613))
0.051420	Team(name=Eagles, rating=(1573.0877526752258, 5763.175694404063))
0.049454	Team(name=Bears, rating=(1568.2953769418104, 5658.668224549107))
0.035592	Team(name=Texans, rating=(1531.140310186461, 5632.326645701227))
0.030325	Team(name=Cowboys, rating=(1529.6153074263095, 5562.54489659418))
0.023878	Team(name=Colts, rating=(1504.7960540254635, 5722.50979574115))
```

A few thoughts:
- There's not much difference between the best/worst teams in the playoffs (Saints over Colts 65%).  Seems a little small for my liking, but it's what the math says 🤷‍♂️ 
  - this is the min-discrepancy optimized (see [Glickman's paper](http://www.glicko.net/research/glicko.pdf)) parameters using the [Hensley "Level of Victory"](http://hensleyratings.com/theory) (CDF'd to be [0, 1]) as the score of games (which had a higher Brier score than the optimized PWP(2) and MOV scoring functions). So it's probably optimal for this "model", but I think a better model would have more separation.
  - "Any given Sunday", I guess.
- Byes matter a lot. Duh.
- The Saints lost 16 points because of their week 17 loss to the Panthers while [resting their starters](http://www.espn.com/nfl/boxscore?gameId=401030768)
  - If I cherry-pick a bit and ignore that game for the Saints, keeping everything else equal, their Super Bowl odds go up to 19.5% (>2%!!)
  - But then I should probably think about injuries and other midseason changes (like the Ravens finally realizing Flacco isn't elite) for teams, which isn't gonna happen anytime soon. Someday
- I'm a bit worried the "best parameters" allow for too much season-to-season carryover, which hurts teams that made big offseason changes (👀 Bears -- Nagy >>> Fox).
  - The amount a team's rating can change during a single season is roughly controlled by the [`variance_over_time`](https://github.com/NathanDeMaria/py-glicko/blob/72a73554970110798c9024f8ec953b49cfe412fb/glicko/run.py#L73) parameter (how much variance is added to each team in the offseason). This is constant for all teams, but teams w/ coaching changes probably merit higher values there than those without.
  - Since I _don't_ do that right now, all teams get some average value, so teams that actually undergo large changes (_and_ large improvements in skill) don't see their ratings change as quickly as they probably deserve